### PR TITLE
First cut

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+node_modules
+npm-debug.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - "4"

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,20 @@
+Copyright (c) 2011-2016 Robots And Pencils
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,63 @@
 [![Build Status](https://travis-ci.org/BeepBoopHQ/beepboop-smallwins-slack.svg)](https://travis-ci.org/BeepBoopHQ/beepboop-smallwins-slack)
 
 ## beepboop-smallwins-slack - Run a multi-team smallwins-slack bot on Beep Boop.
+
+`beepboop-smallwins-slack` allows bot developers to run a [smallwins/slack](https://github.com/smallwins/slack) based bot on the [Beep Boop HQ](http://beepboophq.com) bot hosting platform and support multiple teams.
+
+Supporting multiple teams from a single bot process is made simpler as `beepboop-smallwins-slack` handles creating new RTM connections as new teams add your bot.
+
+## Install
+`npm install --save beepboop-botkit`
+
+## Use
+
+```javascript
+var slack = require('slack')
+var beepboop = require('beepboop-smallwins-slack')
+var workers = beepboop.start(slack, {
+  debug: true
+})
+
+workers.on('start', (bot) => {
+  // on bot started register handlers
+  bot.hello((message) => {
+    // connection succeeded
+    console.log('Got a message: ' + JSON.stringify(message))
+  })
+})
+
+```
+
+see [examples/simple.js](https://github.com/BeepBoopHQ/beepboop-smallwins-slack/blob/master/examples/simple.js) for an example.
+
+## Module: beepboop-botkit
+
+Module has exported function `start`
+
+### BeepBoop.start([options Object])
+
+* `options.debug` Boolean - Logs debug output if true
+* Returns an [EventEmitter2](https://github.com/asyncly/EventEmitter2) instance.  For more information on the events exposed, please see the underlying [`beepboop`](https://github.com/BeepBoopHQ/beepboop-js) module's documentation, as it is what is returned here.
+
+### Accessing slack workers
+
+Since there can be multiple slack workers spawned (1 for each team), these are exposed via a `workers` property on the returned beepboop instance after calling `start()`.  The `workers` property is an object hash where the key is a unique bot token identifying the worker, and the value is the [rtm client](https://github.com/smallwins/slack/blob/master/src/rtm.client.js) as returned from slack's `listen()` function.
+
+```javascript
+var slack = require('slack')
+var beepboop = require('beepboop-smallwins-slack')
+var workers = beepboop.start(slack, {
+  debug: true
+})
+
+// after teams have been added
+workers.on('start', function (bot) {
+  bot.hello(message=> {
+    console.log(`Got a message: ${message}`)
+  })
+})
+```
+
+### Additional Events
+
+This module will bubble up events sent from the [beepboop-js](https://github.com/BeepBoopHQ/beepboop-js#module-beepboop) package

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Supporting multiple teams from a single bot process is made simpler as `beepboop-smallwins-slack` handles creating new RTM connections as new teams add your bot.
 
 ## Install
-`npm install --save beepboop-botkit`
+`npm install --save beepboop-smallwins-slack`
 
 ## Use
 
@@ -30,7 +30,7 @@ workers.on('start', (bot) => {
 
 see [examples/simple.js](https://github.com/BeepBoopHQ/beepboop-smallwins-slack/blob/master/examples/simple.js) for an example.
 
-## Module: beepboop-botkit
+## Module: beepboop-smallwins-slack
 
 Module has exported function `start`
 

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -1,0 +1,44 @@
+'use strict'
+
+var slack = require('slack')
+
+// Beepboop manages the hosting infrastructure for your bot and  publishes events
+// when a team adds, updates, or removes the bot, thereby enabling multitenancy
+// (multiple team instances of bot in one bot process). The beepboop-smallwins-slack package
+// listens for those events handles and starting/stopping the given team bot for you.
+// It is the develper's responsiblity to ensure any state stored outside of the configs
+// set in the project's bot.yml supports multitency (if you allow multiple teams to run your bot)
+var beepboop = require('../index.js')
+
+// beepboop.start returns a EventEmitter that will emit a single event
+// `start` when a new rtm connection is made. The start event passes a single
+// argument of `bot` of type RTM see https://github.com/smallwins/slack#rtm-events
+var workers = beepboop.start(slack, {
+  debug: true
+})
+
+workers.on('start', (bot) => {
+  // on bot started register handlers
+  bot.hello((message) => {
+    // connection succeeded
+    console.log('Got a message: ' + JSON.stringify(message))
+  })
+  // use the webapi to add a emoji reaction on every received message
+  bot.message((message) => {
+    slack.reactions.add({
+      token: bot.token,
+      name: 'wave',
+      timestamp: message.ts,
+      channel: message.channel
+    }, (err, data) => {
+      if (err) {
+        console.log(err)
+      }
+    })
+  })
+})
+// after teams have been removed
+workers.on('stop', function (bot) {
+  // this is an instance of a botkit worker
+  console.log('closed bot' + bot)
+})

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -39,6 +39,6 @@ workers.on('start', (bot) => {
 })
 // after teams have been removed
 workers.on('stop', function (bot) {
-  // this is an instance of a botkit worker
+  // this is an instance of a smallwins rtm client
   console.log('closed bot' + bot)
 })

--- a/index.js
+++ b/index.js
@@ -7,4 +7,5 @@ exports.start = function (slack, config) {
   var beepboop = BeepBoop.start(config)
   var beepBoopSmallwins = new BeepBoopSmallwins(slack, config, beepboop)
   beepBoopSmallwins.start()
+  return beepBoopSmallwins.workers
 }

--- a/index.js
+++ b/index.js
@@ -1,0 +1,10 @@
+'use strict'
+
+var BeepBoop = require('beepboop')
+var BeepBoopSmallwins = require('./lib/beepboop-smallwins-slack.js')
+
+exports.start = function (slack, config) {
+  var beepboop = BeepBoop.start(config)
+  var beepBoopSmallwins = new BeepBoopSmallwins(slack, config, beepboop)
+  beepBoopSmallwins.start()
+}

--- a/index.js
+++ b/index.js
@@ -6,6 +6,5 @@ var BeepBoopSmallwins = require('./lib/beepboop-smallwins-slack.js')
 exports.start = function (slack, config) {
   var beepboop = BeepBoop.start(config)
   var beepBoopSmallwins = new BeepBoopSmallwins(slack, config, beepboop)
-  beepBoopSmallwins.start()
-  return beepBoopSmallwins.workers
+  return beepBoopSmallwins.start()
 }

--- a/lib/beepboop-smallwins-slack.js
+++ b/lib/beepboop-smallwins-slack.js
@@ -11,11 +11,10 @@ var BeepBoopSmallwins = module.exports = function (slack, config, resourcer) {
     retry: Infinity
   }, config || {})
   this.slack = slack
-  this.bots = new EventEmitter()
-  this.bots.tokens = {}
-  this.bots.tokensByResource = {}
-  this.bots.bots = {}
-  this.log = resourcer.log
+  this.workers = new EventEmitter()
+  this.workers.tokens = {}
+  this.workers.tokensByResource = {}
+  this.log = console
   this.resourcer = resourcer
 }
 
@@ -30,57 +29,69 @@ BeepBoopSmallwins.prototype = {
 
         if (!botResource.resource.SlackBotAccessToken) {
           var err = new Error('SlackBotAccessToken not present in message: ' + JSON.stringify(botResource) + '. Bot not added.')
-          self.log.error(err.toString())
+          self.log.info(err)
           return
         }
         // add resource
         self.addResource(botResource)
+        // bubble up beepboop resourcer events to clients
+        this.workers.emit('add_resource', msg)
       })
       .on('update_resource', (msg) => {
         self.updateResource(BotResource(msg))
+        // bubble up beepboop resourcer events to clients
+        this.workers.emit('update_resource', msg)
       })
       .on('remove_resource', (msg) => {
-        var botResource = BotResource(msg)
-        self.removeResource(botResource.id)
+        self.removeResource(msg.resourceID)
+        // bubble up beepboop resourcer events to clients
+        this.workers.emit('remove_resource', msg)
       })
       .on('open', () => {
         // on open, remove any existing resources because since we disconnected,
         // the resourcer should have rescheduled them
-        Object.keys(this.bots.tokensByResource).forEach((resourceId) => {
+        Object.keys(this.workers.tokensByResource).forEach((resourceId) => {
           self.log.info('Removing existing resource: ' + resourceId)
           self.removeResource(resourceId)
         })
+        // bubble up beepboop resourcer events to clients
+        this.workers.emit('open')
       })
       .on('close', () => {
-        self.log.error('Disconnected to Beep Boop Bot Resourcer server.')
+        self.log.info('Disconnected to Beep Boop Bot Resourcer server.')
+        // bubble up beepboop resourcer events to clients
+        this.workers.emit('close')
       })
       .on('error', (err) => {
         if (err.code === 'ECONNREFUSED' && err.address === '127.0.0.1') {
-          self.log.error('Error connecting to Beep Boop Resource server . Please review' +
+          self.log.info('Error connecting to Beep Boop Resource server . Please review' +
             'the BeepBoop Smallwins Slack development instructions here: https://github.com/BeepBoopHQ/beepboop-smallwins-slack' +
-            JSON.stringify(err))
+            err)
         } else {
-          self.log.error('Error received from Beep Boop Resurcer ' + JSON.stringify(err))
+          self.log.info('Error received from Beep Boop Resurcer ' + JSON.stringify(err))
         }
-
+        // bubble up beepboop resourcer events to clients
+        this.workers.emit('error', err)
         return this
       })
+    return this.workers
   },
   addResource: function (botResource) {
     var self = this
 
     // check if resource (team instance) already exists. If not, add it.
-    if (!this.bots.bots[botResource.id]) {
+    if (!this.workers.tokensByResource[botResource.id]) {
       var bot = self.slack.rtm.client()
-      bot.token = botResource.slackBotAccessToken
+      bot.token = botResource.resource.SlackBotAccessToken
       bot.started((payload) => {
         bot.team_info = payload.team
         bot.identity = payload.self
-        self.bots[bot.token] = bot
-        self.bots.tokens[payload.team.id] = bot.token
-        self.bots.tokensByResource[botResource.id] = bot.token
+        self.workers[bot.token] = bot
+        self.workers.tokens[payload.team.id] = bot.token
+        self.workers.tokensByResource[botResource.id] = bot.token
       })
       bot.listen({token: bot.token})
+      this.workers.emit('start', bot)
     }
   },
   updateResource: function (botResource) {
@@ -93,15 +104,15 @@ BeepBoopSmallwins.prototype = {
   },
   removeResource: function (botResourceId) {
     var self = this
-
-    if (self.bots.bots[botResourceId]) {
-      var token = self.bots.tokensByResource[botResourceId]
-      var bot = self.bots[token]
+    if (self.workers.tokensByResource[botResourceId]) {
+      var token = self.workers.tokensByResource[botResourceId]
+      var bot = self.workers[token]
       if (bot) {
         bot.close()
-        delete self.bots.bots[token]
-        delete self.bots.tokensByResource[botResourceId]
-        delete self.bots.tokens[bot.team_info.id]
+        delete self.workers[token]
+        delete self.workers.tokensByResource[botResourceId]
+        delete self.workers.tokens[bot.team_info.id]
+        this.workers.emit('stop', bot)
       }
     }
   }}
@@ -110,7 +121,6 @@ function BotResource (message) {
   return {
     id: message.resourceID,
     resource: message.resource,
-    slackBotAccessToken: message.resource.SlackBotAccessToken,
     meta: {
       isNew: message.isNew
     }

--- a/lib/beepboop-smallwins-slack.js
+++ b/lib/beepboop-smallwins-slack.js
@@ -1,0 +1,118 @@
+'use strict'
+
+var deap = require('deap')
+var EventEmitter = require('events')
+
+// Spawns new rtm clients as new teams are added
+// Also closes connections and manages state as teams are removed
+var BeepBoopSmallwins = module.exports = function (slack, config, resourcer) {
+  this.config = deap.update({
+    debug: false,
+    retry: Infinity
+  }, config || {})
+  this.slack = slack
+  this.bots = new EventEmitter()
+  this.bots.tokens = {}
+  this.bots.tokensByResource = {}
+  this.bots.bots = {}
+  this.log = resourcer.log
+  this.resourcer = resourcer
+}
+
+BeepBoopSmallwins.prototype = {
+  start: function () {
+    var self = this
+
+    // Register new bot resource
+    this.resourcer
+      .on('add_resource', (msg) => {
+        var botResource = BotResource(msg)
+
+        if (!botResource.resource.SlackBotAccessToken) {
+          var err = new Error('SlackBotAccessToken not present in message: ' + JSON.stringify(botResource) + '. Bot not added.')
+          self.log.error(err.toString())
+          return
+        }
+        // add resource
+        self.addResource(botResource)
+      })
+      .on('update_resource', (msg) => {
+        self.updateResource(BotResource(msg))
+      })
+      .on('remove_resource', (msg) => {
+        var botResource = BotResource(msg)
+        self.removeResource(botResource.id)
+      })
+      .on('open', () => {
+        // on open, remove any existing resources because since we disconnected,
+        // the resourcer should have rescheduled them
+        Object.keys(this.bots.tokensByResource).forEach((resourceId) => {
+          self.log.info('Removing existing resource: ' + resourceId)
+          self.removeResource(resourceId)
+        })
+      })
+      .on('close', () => {
+        self.log.error('Disconnected to Beep Boop Bot Resourcer server.')
+      })
+      .on('error', (err) => {
+        if (err.code === 'ECONNREFUSED' && err.address === '127.0.0.1') {
+          self.log.error('Error connecting to Beep Boop Resource server . Please review' +
+            'the BeepBoop Smallwins Slack development instructions here: https://github.com/BeepBoopHQ/beepboop-smallwins-slack' +
+            JSON.stringify(err))
+        } else {
+          self.log.error('Error received from Beep Boop Resurcer ' + JSON.stringify(err))
+        }
+
+        return this
+      })
+  },
+  addResource: function (botResource) {
+    var self = this
+
+    // check if resource (team instance) already exists. If not, add it.
+    if (!this.bots.bots[botResource.id]) {
+      var bot = self.slack.rtm.client()
+      bot.token = botResource.slackBotAccessToken
+      bot.started((payload) => {
+        bot.team_info = payload.team
+        bot.identity = payload.self
+        self.bots[bot.token] = bot
+        self.bots.tokens[payload.team.id] = bot.token
+        self.bots.tokensByResource[botResource.id] = bot.token
+      })
+      bot.listen({token: bot.token})
+    }
+  },
+  updateResource: function (botResource) {
+    var self = this
+
+    self.removeResource(botResource)
+    setTimeout(() => {
+      self.addResource(botResource)
+    }, 500)
+  },
+  removeResource: function (botResourceId) {
+    var self = this
+
+    if (self.bots.bots[botResourceId]) {
+      var token = self.bots.tokensByResource[botResourceId]
+      var bot = self.bots[token]
+      if (bot) {
+        bot.close()
+        delete self.bots.bots[token]
+        delete self.bots.tokensByResource[botResourceId]
+        delete self.bots.tokens[bot.team_info.id]
+      }
+    }
+  }}
+
+function BotResource (message) {
+  return {
+    id: message.resourceID,
+    resource: message.resource,
+    slackBotAccessToken: message.resource.SlackBotAccessToken,
+    meta: {
+      isNew: message.isNew
+    }
+  }
+}

--- a/lib/beepboop-smallwins-slack.js
+++ b/lib/beepboop-smallwins-slack.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var deap = require('deap')
-var EventEmitter = require('events')
+var EventEmitter = require('eventemitter2')
 
 // Spawns new rtm clients as new teams are added
 // Also closes connections and manages state as teams are removed

--- a/package.json
+++ b/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "beepboop-smallwins-slack",
+  "version": "1.0.0",
+  "description": "Run a smallwins-slack bot on BeepBoopHQ",
+  "main": "index.js",
+  "scripts": {
+    "test": "standard && mocha test"
+  },
+  "homepage": "http://beepboophq.com",
+  "bugs": {
+    "url": "https://github.com/BeepBoopHQ/beepboop-smallwins-slack/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/BeepBoopHQ/beepboop-smallwins-slack"
+  },
+  "keywords": [
+    "slack",
+    "smallwins-slack",
+    "beepboop",
+    "beep",
+    "boop",
+    "bot"
+  ],
+  "author": "Curtis Allen <curtis.allen@robotsandpencils.com> (https://beepboophq.com)",
+  "license": "MIT",
+  "dependencies": {
+    "beepboop": "^1.1.0",
+    "deap": "^1.0.0"
+  },
+  "devDependencies": {
+    "standard": "^6.0.8",
+    "mocha": "^2.4.5",
+    "chai": "^3.5.0",
+    "sinon": "^1.17.3"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "license": "MIT",
   "dependencies": {
     "beepboop": "^1.1.0",
-    "deap": "^1.0.0"
+    "deap": "^1.0.0",
+    "eventemitter2": "^1.0.5"
   },
   "devDependencies": {
     "standard": "^6.0.8",

--- a/test/test-beepboop-smallwins-slack.js
+++ b/test/test-beepboop-smallwins-slack.js
@@ -1,0 +1,141 @@
+/* global describe, it, before, beforeEach, afterEach, after */
+var chai = require('chai')
+var assert = chai.assert
+var expect = chai.expect
+var events = require('events')
+var sinon = require('sinon')
+var BeepBoop = require('beepboop')
+var BeepBoopSmallwins = require('../lib/beepboop-smallwins-slack.js')
+describe('Smallwins Slack', () => {
+  var socket
+  var resourcer
+  var clock
+
+  chai.should()
+
+  before(() => { clock = sinon.useFakeTimers() })
+  after(() => { clock.restore() })
+  beforeEach(() => {
+    resourcer = BeepBoop.start({logger: console})
+    socket = new events.EventEmitter()
+    socket.send = function () {}
+    sinon.stub(resourcer, 'newWebSocket').returns(socket)
+
+    resourcer.connect(socket)
+  })
+
+  afterEach(function () {
+    resourcer.newWebSocket.restore()
+  })
+  describe('Resource', () => {
+    it('should remove existing tokens on open', (done) => {
+      var bbSmallwins = new BeepBoopSmallwins({}, {}, resourcer)
+      bbSmallwins.start()
+      bbSmallwins.removeResource = sinon.spy()
+      bbSmallwins.workers.tokensByResource = {'resource1': 'token1'}
+      resourcer.emit('open', {})
+      assert(bbSmallwins.removeResource.called)
+      done()
+    })
+    it("should add a resource when it's added", (done) => {
+      var stub = getSlackClientStub()
+      var slack = {
+        'rtm': {
+          client: stub
+        }
+      }
+      var bbSmallwins = new BeepBoopSmallwins(slack, {}, resourcer)
+      var workers = bbSmallwins.start()
+      resourcer.emit('add_resource', getAddResource())
+      workers.tokens['someteam'].should.equal('xoxb-xxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx')
+      workers.tokensByResource['resource1'].should.equal('xoxb-xxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx')
+      workers['xoxb-xxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx'].should.have.property('team_info')
+      done()
+    })
+    it('should update resource', (done) => {
+      var bbSmallwins = new BeepBoopSmallwins({}, {}, resourcer)
+      bbSmallwins.start()
+      bbSmallwins.removeResource = sinon.spy()
+      bbSmallwins.addResource = sinon.spy()
+      resourcer.emit('update_resource', getUpdateResource())
+      assert(bbSmallwins.removeResource.called)
+      clock.tick(500) // advance time by 500ms
+      assert(bbSmallwins.addResource.called)
+      done()
+    })
+    it('should remove resource', (done) => {
+      var stub = getSlackClientStub()
+      var slack = {
+        'rtm': {
+          client: stub
+        }
+      }
+      var bbSmallwins = new BeepBoopSmallwins(slack, {}, resourcer)
+      var workers = bbSmallwins.start()
+      resourcer.emit('add_resource', getAddResource())
+      resourcer.emit('remove_resource', {'resourceID': 'resource1'})
+      expect(workers.tokens).be.empty
+      expect(workers.tokensByResource).be.empty
+      expect(workers['xoxb-xxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx']).to.not.exist
+      done()
+    })
+  })
+})
+
+function getAddResource () {
+  return {
+    'type': 'add_resource',
+    'date': '2016-03-18T20:58:52.907804207Z',
+    'msgID': '106e930b-1c83-4406-801d-caf04e30da71',
+    // unique identifier for this team connection
+    'resourceID': 'resource1',
+    'resourceType': 'SlackApp',
+    'resource': {
+      // Token you should use to connect to the Slack RTM API
+      'SlackBotAccessToken': 'xoxb-xxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx',
+      'SlackBotUserID': 'XXXXXXXXX',
+      'SlackBotUserName': 'name-of-bot-user',
+      // Regular access token - will contain additional scopes requested
+      'SlackAccessToken': 'XXXXXXXXX',
+      'SlackIncomingWebhookConfigURL': 'https://<slack-team-name>.slack.com/services/XXXXXXXXX',
+      'SlackIncomingWebhookChannel': '#channel-name',
+      'SlackTeamName': 'Name of Team',
+      'SlackTeamID': 'XXXXXXXXX',
+      'SlackUserID': 'XXXXXXXXX',
+      'CUSTOM_CONFIG': 'Value for CUSTOM_CONFIG'
+    }
+  }
+}
+
+function getUpdateResource () {
+  return {
+    'type': 'update_resource',
+    'date': '2016-03-18T21:02:49.719711877Z',
+    'msgID': '2ca94d34-ef04-4167-8363-c778d129b8f1',
+    'resourceID': '75f9c7334807421bb914c1cff8d4486c',
+    'resource': {
+      // Token you should use to connect to the Slack RTM API
+      'SlackBotAccessToken': 'xoxb-xxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxx',
+      'SlackBotUserID': 'XXXXXXXXX',
+      'SlackBotUserName': 'name-of-bot-user',
+      // Regular access token - will contain additional scopes requested
+      'SlackAccessToken': 'XXXXXXXXX',
+      'SlackTeamName': 'Name of Team',
+      'SlackTeamID': 'XXXXXXXXX',
+      'SlackUserID': 'XXXXXXXXX',
+      'CUSTOM_CONFIG': 'Updated Value for Config'
+    }
+  }
+}
+function getSlackClientStub () {
+  return function () {
+    return {
+      'tokens': {},
+      started: (payload) => {
+        return payload({'team': {'id': 'someteam'}})
+      },
+      close: sinon.spy(),
+      listen: sinon.spy()
+    }
+  }
+}

--- a/test/test-beepboop-smallwins-slack.js
+++ b/test/test-beepboop-smallwins-slack.js
@@ -38,12 +38,7 @@ describe('Smallwins Slack', () => {
       done()
     })
     it("should add a resource when it's added", (done) => {
-      var stub = getSlackClientStub()
-      var slack = {
-        'rtm': {
-          client: stub
-        }
-      }
+      var slack = getSlackClientStub()
       var bbSmallwins = new BeepBoopSmallwins(slack, {}, resourcer)
       var workers = bbSmallwins.start()
       resourcer.emit('add_resource', getAddResource())
@@ -64,12 +59,7 @@ describe('Smallwins Slack', () => {
       done()
     })
     it('should remove resource', (done) => {
-      var stub = getSlackClientStub()
-      var slack = {
-        'rtm': {
-          client: stub
-        }
-      }
+      var slack = getSlackClientStub()
       var bbSmallwins = new BeepBoopSmallwins(slack, {}, resourcer)
       var workers = bbSmallwins.start()
       resourcer.emit('add_resource', getAddResource())
@@ -128,14 +118,18 @@ function getUpdateResource () {
   }
 }
 function getSlackClientStub () {
-  return function () {
-    return {
-      'tokens': {},
-      started: (payload) => {
-        return payload({'team': {'id': 'someteam'}})
-      },
-      close: sinon.spy(),
-      listen: sinon.spy()
+  return {
+    'rtm': {
+      client: function () {
+        return {
+          'tokens': {},
+          started: (payload) => {
+            return payload({'team': {'id': 'someteam'}})
+          },
+          close: sinon.spy(),
+          listen: sinon.spy()
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
#### What's this PR do?

Spawns [smallwins/slack](https://github.com/smallwins/slack) RTM clients based on [beepboop resourcer](https://github.com/BeepBoopHQ/beepboop-js) events. 
#### Where should the reviewer start?

`lib/beepboop-smallwins-slack.js`
#### How should this be manually tested?

I've tried to add unit tests to cover every state transition. Run tests 

```
npm install
npm test
```

Please also test the `examples/simple.js` bot. From a beepboop project get some dev resourcer credentials, ensure you run the beepboop provided command `export BEEPBOOP_ID=<your id> BEEPBOOP_RESOURCER=wss://devresourcer.beepboophq.com/ws BEEPBOOP_TOKEN=<your token>` then run 

```
npm i slack
node examples/simple.js
```

Direct message the bot it will add an emoji reaction to every message. Use the DEV resourcer tab to add and remove teams ensure the bot connects and disconnects as expected. 
#### Any background context you want to provide?

I went back and forth about how I'd like to expose the RTM bot instances. This project is based off of [beepboop-botkit](https://github.com/BeepBoopHQ/beepboop-botkit) it seems that module had to do emit some specific botkit events that weren't useful for the `smallwins/slack` client.

Should I bubble up the `beepboop-js` events? Is that useful? 
Right now I emit a event on bot `start` and `close` with the bot rtm client, is this the right level of abstraction? 

We'll also need a NPM project created and publish this once merged
#### Were the tests updated?

oh yeah
