### PR TITLE
adds reconnect logic and ping/pong for ws connection

### DIFF
--- a/lib/beepboop-smallwins-slack.js
+++ b/lib/beepboop-smallwins-slack.js
@@ -1,6 +1,7 @@
 'use strict'
 
 var deap = require('deap')
+var Back = require('back')
 var EventEmitter = require('eventemitter2')
 
 // Spawns new rtm clients as new teams are added
@@ -70,8 +71,6 @@ BeepBoopSmallwins.prototype = {
         } else {
           self.log.info('Error received from Beep Boop Resurcer ' + JSON.stringify(err))
         }
-        // bubble up beepboop resourcer events to clients
-        this.workers.emit('error', err)
         return this
       })
     return this.workers
@@ -80,19 +79,93 @@ BeepBoopSmallwins.prototype = {
     var self = this
 
     // check if resource (team instance) already exists. If not, add it.
-    if (!this.workers.tokensByResource[botResource.id]) {
-      var bot = self.slack.rtm.client()
-      bot.token = botResource.resource.SlackBotAccessToken
-      bot.started((payload) => {
-        bot.team_info = payload.team
-        bot.identity = payload.self
-        self.workers[bot.token] = bot
-        self.workers.tokens[payload.team.id] = bot.token
-        self.workers.tokensByResource[botResource.id] = bot.token
-      })
-      bot.listen({token: bot.token})
-      this.workers.emit('start', bot)
+    if (this.workers.tokensByResource[botResource.id]) {
+      return self.log.info('Received add_resource event for team that already exists, ignoring: ' + botResource.id)
     }
+
+    var retryBackoff
+
+    var bot = self.slack.rtm.client()
+    bot.token = botResource.resource.SlackBotAccessToken
+    bot.started((payload) => {
+      bot.team_info = payload.team
+      bot.identity = payload.self
+      self.workers[bot.token] = bot
+      self.workers.tokens[payload.team.id] = bot.token
+      self.workers.tokensByResource[botResource.id] = bot.token
+    })
+
+    function reconnect () {
+      var options = {
+        minDelay: 1000,
+        maxDelay: 30000,
+        retries: self.config.retry
+      }
+      var back = retryBackoff || (retryBackoff = new Back(options))
+      return back.backoff(function (fail) {
+        if (fail) {
+          self.log.info('Reconnect failed after #' + back.settings.attempt + ' attempts and ' + back.settings.timeout + 'ms')
+          return
+        }
+
+        self.log.info('...reconnect attempt #' + back.settings.attempt + ' of ' + options.retries + ' being made after ' + back.settings.timeout + 'ms')
+        listen()
+      })
+    }
+
+    function listen () {
+      bot.listen({token: bot.token}, function (err) {
+        if (err) {
+          self.log.error('Error calling bot.listen: ', err)
+          return reconnect()
+        }
+        retryBackoff = null
+        setupRTM()
+        self.workers.emit('start', bot)
+      })
+    }
+
+    function setupRTM () {
+      var lastPong = null
+      var pingIntervalId = null
+
+      bot.ws.on('pong', function (obj) {
+        lastPong = Date.now()
+      })
+
+      // Setup ping/pong to detect stale connections
+      pingIntervalId = setInterval(function () {
+        console.log('pinging ws')
+        if (lastPong && lastPong + 12000 < Date.now()) {
+          self.log.info('Stale RTM connection, closing RTM')
+
+          lastPong = null
+          if (pingIntervalId !== null) {
+            clearInterval(pingIntervalId)
+            pingIntervalId = null
+          }
+          bot.close()
+          return
+        }
+
+        bot.ws.ping(null, null, true)
+      }, 5000)
+
+      // Add reconnection logic
+      bot.ws.on('close', function (code, message) {
+        if (pingIntervalId !== null) {
+          clearInterval(pingIntervalId)
+          pingIntervalId = null
+        }
+        // ABNORMAL_CLOSE event - try to reconnect
+        if (code === 1006) {
+          self.log.info('Abnormal websocket close event, attempting to reconnect')
+          reconnect()
+        }
+      })
+    }
+
+    listen()
   },
   updateResource: function (botResource) {
     var self = this

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "author": "Curtis Allen <curtis.allen@robotsandpencils.com> (https://beepboophq.com)",
   "license": "MIT",
   "dependencies": {
+    "back": "^1.0.1",
     "beepboop": "^1.1.0",
     "deap": "^1.0.0",
     "eventemitter2": "^1.0.5"


### PR DESCRIPTION
- Adds ping/pong message handling to the slack rtm connection to detect stale websocket connections
- Adds reconnect logic to the slack rtm websocket w/ backoff logic
- Removes bubbling up of resourcer error, if we emit `error` on an EventEmitter and there's no default handler, process throws an exception and is killed.  Seems like we're ok not bubbling that up (we don't in beepboop-botkit)
