### PR TITLE
fixes and optimizes some of the slack ws reconnect logic

### DIFF
--- a/lib/beepboop-smallwins-slack.js
+++ b/lib/beepboop-smallwins-slack.js
@@ -129,6 +129,26 @@ BeepBoopSmallwins.prototype = {
       var lastPong = null
       var pingIntervalId = null
 
+      // monkey-patch close fn to make sure we cleanup any ping/pong or reconnect attempts
+      var _close = bot.close
+      bot.close = function () {
+        // cancel any ping/pong interval we have
+        clearPingPong()
+        // cancel any retry that is in progress
+        if (retryBackoff) {
+          retryBackoff.close()
+        }
+        _close.apply(bot, arguments)
+      }
+
+      function clearPingPong () {
+        lastPong = null
+        if (pingIntervalId !== null) {
+          clearInterval(pingIntervalId)
+          pingIntervalId = null
+        }
+      }
+
       bot.ws.on('pong', function (obj) {
         lastPong = Date.now()
       })
@@ -138,13 +158,10 @@ BeepBoopSmallwins.prototype = {
         if (lastPong && lastPong + 12000 < Date.now()) {
           self.log.info('Stale RTM connection, closing RTM')
 
-          lastPong = null
-          if (pingIntervalId !== null) {
-            clearInterval(pingIntervalId)
-            pingIntervalId = null
-          }
-          bot.close()
-          return
+          clearPingPong()
+          // immediately shuts down the connection w/o trying to send msg to server to close
+          // this will trigger an ABNORMAL_CLOSE event when connection is broken, firing `reconnect()`
+          return bot.ws.terminate()
         }
 
         bot.ws.ping(null, null, true)
@@ -152,10 +169,7 @@ BeepBoopSmallwins.prototype = {
 
       // Add reconnection logic
       bot.ws.on('close', function (code, message) {
-        if (pingIntervalId !== null) {
-          clearInterval(pingIntervalId)
-          pingIntervalId = null
-        }
+        clearPingPong()
         // ABNORMAL_CLOSE event - try to reconnect
         if (code === 1006) {
           self.log.info('Abnormal websocket close event, attempting to reconnect')


### PR DESCRIPTION
- monkey patch `bot.close()` to make sure and cancel any pending reconnect, and clear ping/pong interval
- for stale connection changes to use `bot.ws.terminate()` - which ends the connection immediately instead of attempting to write a close msg to server.  This triggers an ABNORMAL_CLOSE, which causes a reconnect to start

If `bot.close()` is called explicitly (either by us in the `remove_resource` event, or by the user's code) - a normal `close` event will fire on the ws, so no reconnect will occur.
